### PR TITLE
saltstack*: Place the 'supportability' comment within `cask` block

### DIFF
--- a/Casks/saltstack-3000.rb
+++ b/Casks/saltstack-3000.rb
@@ -1,5 +1,5 @@
-# Phase 3 upport until Aug 31, 2021
 cask "saltstack-3000" do
+  # Phase 3 support until Aug 31, 2021
   version "3000.9"
   sha256 "f45dd0e4b818417f53869dd62c3d3e6872c16d7b303359fd330d671ecb5e951d"
 

--- a/Casks/saltstack-3001.rb
+++ b/Casks/saltstack-3001.rb
@@ -1,5 +1,5 @@
-# Phase 3 upport until Dec 31, 2021
 cask "saltstack-3001" do
+  # Phase 3 support until Dec 31, 2021
   version "3001.7"
   sha256 "1f5dbdf778c755cafd9201fbd70d60dd03f5cd647d73f7b1ee198d82a101e694"
 

--- a/Casks/saltstack-3002.rb
+++ b/Casks/saltstack-3002.rb
@@ -1,5 +1,5 @@
-# Phase 3 upport until Apr 21, 2022
 cask "saltstack-3002" do
+  # Phase 3 support until Apr 21, 2022
   version "3002.6"
   sha256 "8aaf7f0fc14748820bbe34d938baa9283d38a2b6b62ba9cd22fd96142d8d67fd"
 

--- a/Casks/saltstack.rb
+++ b/Casks/saltstack.rb
@@ -1,5 +1,5 @@
-# Phase 3 upport until Sep 30, 2022
 cask "saltstack" do
+  # Phase 3 support until Sep 30, 2022
   version "3003"
   sha256 "420c402baf5df71270e4068b64b2b89bc50157c141e2ac95c5a86efd9a4258f2"
 


### PR DESCRIPTION
- Before, `brew bump-cask-pr` would fail horribly because, tracing it back, the Cask file contents didn't match the regex (which expects the file starts with `cask "name" do`).
- We don't have any audits for this (otherwise they'd have complained), and I'm not very familiar with Casks, but/and I'm not sure this was ever valid syntax so if it's worth fixing the bug? So I thought it better to fix here in this tap so that `brew bump-cask-pr` works here.
- Related issue: https://github.com/Homebrew/brew/issues/11633.
